### PR TITLE
Fix calendar on mobile to respond to user input

### DIFF
--- a/assets/javascripts/discourse/components/events-calendar-day.js
+++ b/assets/javascripts/discourse/components/events-calendar-day.js
@@ -63,6 +63,23 @@ export default Component.extend({
     }
   },
 
+  touchStart(event) {
+    this.touchStartX = event.touches[0].clientX;
+    this.touchStartY = event.touches[0].clientY;
+  },
+
+  touchEnd(event) {
+    const touchEndX = event.changedTouches[0].clientX;
+    const touchEndY = event.changedTouches[0].clientY;
+
+    if (
+      Math.abs(touchEndX - this.touchStartX) < 10 &&
+      Math.abs(touchEndY - this.touchStartY) < 10
+    ) {
+      this.click();
+    }
+  },
+
   @discourseComputed("index")
   date() {
     const day = this.get("day");

--- a/assets/stylesheets/mobile/events.scss
+++ b/assets/stylesheets/mobile/events.scss
@@ -93,3 +93,25 @@
 body.calendar {
   -webkit-tap-highlight-color: transparent;
 }
+
+/* Increase the touch area for calendar navigation buttons */
+.events-calendar-navigation .d-button {
+  padding: 10px;
+}
+
+/* Add media queries to improve the Calendar's responsiveness and user interaction on mobile devices */
+@media (max-width: 600px) {
+  .events-calendar-body {
+    .day {
+      height: 50px;
+    }
+
+    .weekday {
+      height: 20px;
+    }
+  }
+
+  .events-calendar-card {
+    padding: 10px;
+  }
+}


### PR DESCRIPTION
Add touch event handling for mobile calendar navigation and date selection.

* **`assets/javascripts/discourse/components/events-calendar-day.js`**
  - Add `touchStart` and `touchEnd` methods to handle touch events for selecting dates on mobile devices.

* **`assets/stylesheets/mobile/events.scss`**
  - Increase the touch area for calendar navigation buttons.
  - Add media queries to improve the calendar's responsiveness and user interaction on mobile devices.

