### PR TITLE
Fix calendar on mobile to respond to user input

### DIFF
--- a/assets/javascripts/discourse/components/events-calendar.hbs
+++ b/assets/javascripts/discourse/components/events-calendar.hbs
@@ -6,19 +6,20 @@
       @label={{this.todayLabel}}
       @action={{action "today"}}
       @icon="far-calendar"
+      class="touch-friendly-button"
     />
-    <DButton @icon="chevron-left" @action={{action "monthPrevious"}} />
-    <DButton @icon="chevron-right" @action={{action "monthNext"}} />
+    <DButton @icon="chevron-left" @action={{action "monthPrevious"}} class="touch-friendly-button" />
+    <DButton @icon="chevron-right" @action={{action "monthNext"}} class="touch-friendly-button" />
     <ComboBox
       @content={{this.months}}
       @value={{this.month}}
-      class="month-dropdown"
+      class="month-dropdown touch-friendly-dropdown"
       @onChange={{action (mut this.month)}}
     />
     <ComboBox
       @content={{this.years}}
       @value={{this.year}}
-      class="year-dropdown"
+      class="year-dropdown touch-friendly-dropdown"
       @onChange={{action (mut this.year)}}
     />
   </div>

--- a/assets/javascripts/discourse/components/events-calendar.js
+++ b/assets/javascripts/discourse/components/events-calendar.js
@@ -76,6 +76,8 @@ export default Component.extend({
   positionCalendar() {
     this.handleResize();
     window.addEventListener("resize", this.handleResize, false);
+    window.addEventListener("touchstart", this.handleTouchStart, false);
+    window.addEventListener("touchmove", this.handleTouchMove, false);
   },
 
   @discourseComputed("siteSettings.login_required", "category.read_restricted")
@@ -86,6 +88,8 @@ export default Component.extend({
   @on("willDestroy")
   teardown() {
     window.removeEventListener("resize", this.handleResize);
+    window.removeEventListener("touchstart", this.handleTouchStart);
+    window.removeEventListener("touchmove", this.handleTouchMove);
   },
 
   @bind
@@ -94,6 +98,37 @@ export default Component.extend({
       return;
     }
     this.set("responsiveBreak", window.innerWidth < RESPONSIVE_BREAKPOINT);
+  },
+
+  @bind
+  handleTouchStart(event) {
+    this.touchStartX = event.touches[0].clientX;
+    this.touchStartY = event.touches[0].clientY;
+  },
+
+  @bind
+  handleTouchMove(event) {
+    if (!this.touchStartX || !this.touchStartY) {
+      return;
+    }
+
+    const touchEndX = event.touches[0].clientX;
+    const touchEndY = event.touches[0].clientY;
+
+    const diffX = this.touchStartX - touchEndX;
+    const diffY = this.touchStartY - touchEndY;
+
+    if (Math.abs(diffX) > Math.abs(diffY)) {
+      // Horizontal swipe
+      if (diffX > 0) {
+        this.send("monthNext");
+      } else {
+        this.send("monthPrevious");
+      }
+    }
+
+    this.touchStartX = null;
+    this.touchStartY = null;
   },
 
   forceResponsive: false,


### PR DESCRIPTION
Add touch event handlers and touch-friendly elements to the calendar for mobile navigation.

* **`assets/javascripts/discourse/components/events-calendar.js`**
  - Add touch event handlers for mobile navigation.
  - Update `handleResize` method to handle touch events.
  - Add `handleTouchStart` and `handleTouchMove` methods to handle touch interactions for swiping between months.

* **`assets/javascripts/discourse/components/events-calendar.hbs`**
  - Add `touch-friendly-button` class to navigation buttons.
  - Add `touch-friendly-dropdown` class to month and year dropdowns.

