### PR TITLE
Fix calendar responsiveness on mobile

### DIFF
--- a/assets/javascripts/discourse/components/events-calendar.hbs
+++ b/assets/javascripts/discourse/components/events-calendar.hbs
@@ -55,7 +55,7 @@
   @currentMonth={{this.currentMonth}}
   @currentDate={{this.currentDate}}
   @selectDate={{action "selectDate"}}
-  @canSelectDate={{this.anSelectDate}}
+  @canSelectDate={{this.canSelectDate}}
   @showEvents={{this.showEvents}}
   @responsive={{this.responsive}}
 />

--- a/assets/stylesheets/common/events.scss
+++ b/assets/stylesheets/common/events.scss
@@ -690,3 +690,27 @@ ul.events-webcal-notices {
     background-color: var(--success);
   }
 }
+
+/* Media queries for mobile responsiveness */
+@media (max-width: 768px) {
+  .events-calendar-body {
+    .day {
+      height: 80px;
+    }
+  }
+
+  .events-calendar-navigation {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .events-calendar-subscription-links {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .select-kit.month-dropdown,
+  .select-kit.year-dropdown {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Improve mobile responsiveness of the calendar component.

* Add media queries in `assets/stylesheets/common/events.scss` to handle mobile responsiveness.
* Adjust layout and styles in `assets/javascripts/discourse/components/events-calendar.hbs` to ensure the calendar is responsive on mobile.

