### PR TITLE
Fix calendar header columns to reflect new 'start week on' value

### DIFF
--- a/assets/javascripts/discourse/components/events-calendar-body.gjs
+++ b/assets/javascripts/discourse/components/events-calendar-body.gjs
@@ -1,15 +1,35 @@
 import Component from "@glimmer/component";
 import { firstDayOfWeek } from "../lib/date-utilities";
-import EventsCalendarDay from "./events-calendar-day";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class EventsCalendarBody extends Component {
+  @service currentUser;
+  @tracked firstDayOfWeek = this.currentUser.custom_fields.calendar_first_day_week;
+
   get weekdays() {
     let data = moment.localeData();
     let weekdays = this.args.responsive ? data.weekdaysMin() : data.weekdays();
-    let firstDay = firstDayOfWeek();
+    let firstDay = this.firstDayOfWeek;
     let beforeFirst = weekdays.splice(0, firstDay);
     weekdays.push(...beforeFirst);
     return weekdays;
+  }
+
+  @action
+  updateFirstDayOfWeek() {
+    this.firstDayOfWeek = this.currentUser.custom_fields.calendar_first_day_week;
+  }
+
+  constructor() {
+    super(...arguments);
+    this.currentUser.addObserver('custom_fields.calendar_first_day_week', this, this.updateFirstDayOfWeek);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.currentUser.removeObserver('custom_fields.calendar_first_day_week', this, this.updateFirstDayOfWeek);
   }
 
   <template>

--- a/assets/javascripts/discourse/connectors/user-preferences-interface/calendar-preferences.js
+++ b/assets/javascripts/discourse/connectors/user-preferences-interface/calendar-preferences.js
@@ -41,5 +41,16 @@ export default {
           : localeFirst;
       controller.set("model.custom_fields.calendar_first_day_week", first);
     }
+
+    // Update the custom field when the user changes their preference
+    component.addObserver(
+      "controller.model.custom_fields.calendar_first_day_week",
+      function () {
+        const newFirstDay = controller.get(
+          "model.custom_fields.calendar_first_day_week"
+        );
+        controller.set("model.calendar_first_day_week", newFirstDay);
+      }
+    );
   },
 };

--- a/assets/javascripts/discourse/lib/date-utilities.js
+++ b/assets/javascripts/discourse/lib/date-utilities.js
@@ -204,8 +204,9 @@ function eventCalculations(day, start, end) {
 const allowedFirstDays = [6, 0, 1]; // Saturday, Sunday, Monday
 function firstDayOfWeek() {
   const user = User.current();
-  return user && allowedFirstDays.indexOf(user.calendar_first_day_week) > -1
-    ? user.calendar_first_day_week
+  const customFirstDay = user && user.custom_fields && user.custom_fields.calendar_first_day_week;
+  return customFirstDay && allowedFirstDays.indexOf(customFirstDay) > -1
+    ? customFirstDay
     : moment().weekday(0).day();
 }
 


### PR DESCRIPTION
Update the calendar to reflect changes in the 'start week on' value.

* Modify `assets/javascripts/discourse/components/events-calendar-body.gjs` to update the `weekdays` getter to use the `calendar_first_day_week` custom field and add a computed property to watch for changes in the custom field. Add an action to update the first day of the week and ensure the component re-renders when the custom field changes.
* Modify `assets/javascripts/discourse/lib/date-utilities.js` to update the `firstDayOfWeek` function to use the `calendar_first_day_week` custom field and ensure it returns the correct first day of the week based on the custom field.
* Modify `assets/javascripts/discourse/connectors/user-preferences-interface/calendar-preferences.js` to update the `setupComponent` function to set the `calendar_first_day_week` custom field and ensure the custom field is set correctly based on user preferences. Add an observer to update the custom field when the user changes their preference.

