### PR TITLE
Remove placeholder text from EventForm component

### DIFF
--- a/assets/javascripts/discourse/components/custom-wizard-field-event.hbs
+++ b/assets/javascripts/discourse/components/custom-wizard-field-event.hbs
@@ -2,5 +2,4 @@
   @event={{@event}}
   @eventTimezones={{this.eventTimezones}}
   @updateEvent={{action "updateEvent"}}
-  @placeholder=""
 />


### PR DESCRIPTION
Remove placeholder attribute from EventForm component in custom-wizard-field-event.hbs

* Remove the `@placeholder` attribute from the `EventForm` component
